### PR TITLE
Fix an invalid constructor for iconv

### DIFF
--- a/apiserver/carriers/kr.logen/index.js
+++ b/apiserver/carriers/kr.logen/index.js
@@ -1,4 +1,4 @@
-const iconv  = new require('iconv').Iconv('EUC-KR', 'UTF-8//TRANSLIT//IGNORE')
+const iconv  = new (require('iconv').Iconv)('EUC-KR', 'UTF-8//TRANSLIT//IGNORE')
 const axios = require('axios')
 const { JSDOM } = require('jsdom')
 const qs = require('querystring')


### PR DESCRIPTION
Hello.
I simply fixed a problem for an invalid use of new and require().
I could catch this by the static analysis tool I am developing :)

See the below link for details:
https://deepscan.io/dashboard/#view=project&tid=1352&pid=3790&bid=32684&subview=issues&status=%5B%22fixed%22%5D

Please check.
Cheers.