### PR TITLE
kr.lotte: 배송 상태 이력 위치에 포함된 불필요한 공백 제거

### DIFF
--- a/packages/apiserver/carriers/kr.lotte/index.js
+++ b/packages/apiserver/carriers/kr.lotte/index.js
@@ -58,7 +58,7 @@ function getTrack(trackId) {
                 status: parseStatus(tds[0].textContent),
                 time: `${tds[1].textContent.replace(/\s+/g, 'T')}:00+09:00`,
                 location: {
-                  name: tds[2].textContent,
+                  name: tds[2].textContent.trim(),
                 },
                 description: tds[3].textContent,
               });


### PR DESCRIPTION
| Before | After |
|:---:|:---:|
| <img width="191" alt="after" src="https://user-images.githubusercontent.com/931655/178183178-3d32968a-9fd4-4b37-bc6c-9458b1b4789e.png"> | <img width="738" alt="before" src="https://user-images.githubusercontent.com/931655/178183182-d0aefc84-12f4-4e06-8d74-34da619b2f59.png"> |
