### PR TITLE
경동택배 시간 포맷팅 시 '.0' 제거

### DIFF
--- a/packages/apiserver/carriers/kr.kdexp/index.js
+++ b/packages/apiserver/carriers/kr.kdexp/index.js
@@ -41,7 +41,9 @@ function getTrack(trackId) {
           shippingInformation.progresses.push({
             time:
               progress.reg_date !== '알수없음'
-                ? `${progress.reg_date.replace(' ', 'T')}+09:00`
+                ? `${progress.reg_date
+                    .replace(' ', 'T')
+                    .replace('.0', '')}+09:00`
                 : undefined,
             status: {
               id: STATUS_ID_MAP[progress.stat] || 'in_transit',


### PR DESCRIPTION
## 배경

Python에서 파싱하지 못하는 문제가 있습니다.

## 스크린샷

| Before | After |
|:---:|:---:|
| <img width="346" alt="before" src="https://user-images.githubusercontent.com/931655/203999848-43bedc6e-8ac2-49db-ac10-f3969a27b788.png"> | <img width="330" alt="after" src="https://user-images.githubusercontent.com/931655/203999850-a5a2124c-c95d-4b7c-9801-225fa9643178.png"> |
