### PR TITLE
kr.hdexp: 합동택배 날짜 포맷에서 밀리초(.0) 제거

### DIFF
--- a/packages/apiserver/carriers/kr.hdexp/index.js
+++ b/packages/apiserver/carriers/kr.hdexp/index.js
@@ -44,7 +44,9 @@ function getTrack(trackId) {
           shippingInformation.progresses.push({
             time:
               progress.reg_date !== '알수없음'
-                ? `${progress.reg_date.replace(' ', 'T')}+09:00`
+                ? `${progress.reg_date
+                    .replace(' ', 'T')
+                    .replace('.0', '')}+09:00`
                 : undefined,
             status: {
               id: STATUS_ID_MAP[progress.stat] || 'in_transit',


### PR DESCRIPTION
## 배경

- #153 과 비슷합니다.

## 스크린샷

| Before | After |
|:---:|:---:|
| <img width="344" alt="before" src="https://user-images.githubusercontent.com/931655/204154254-f5a927c1-4ad2-4693-927c-4591f941d265.png"> | <img width="329" alt="after" src="https://user-images.githubusercontent.com/931655/204154256-36af6ffd-f384-41d6-8de9-b55e56dee364.png"> |
