### PR TITLE
kr.cjlogistics: 배송 조회 시간 문제 수정

### DIFF
--- a/packages/apiserver/carriers/kr.cjlogistics/index.js
+++ b/packages/apiserver/carriers/kr.cjlogistics/index.js
@@ -15,7 +15,7 @@ const STATUS_MAP = {
 };
 
 function parseTime(s) {
-  return `${s.replace(' ', 'T').substring(0, s.lastIndexOf('.'))}+09:00`;
+  return `${s.replace(' ', 'T')}+09:00`;
 }
 
 function getTrack(trackId) {


### PR DESCRIPTION
기존에 시간 처리 방식대로 하면 **+09:00**만 넘어오는 상황이 돼서 처리되기 전 값을 콘솔로 출력해보니 **yyyy-mm-dd hh:mm:ss**로 만 출력되서 뒷부분 `.substring(0, s.lastIndexOf('.'))`을 제거해보니 시간 처리가 잘됩니다. 혹여나 한번 더 체크를 해보는게 좋아 보이네요.