### PR TITLE
롯데 택배 배송완료 시간 파싱 에러 수정

### DIFF
--- a/packages/apiserver/carriers/kr.lotte/index.js
+++ b/packages/apiserver/carriers/kr.lotte/index.js
@@ -56,7 +56,7 @@ function getTrack(trackId) {
 
               result.unshift({
                 status: parseStatus(tds[0].textContent),
-                time: `${tds[1].textContent.replace(/\s+/g, 'T')}:00+09:00`,
+                time: `${tds[1].textContent.trim().replace(/\s+/g, 'T')}:00+09:00`,
                 location: {
                   name: tds[2].textContent.trim(),
                 },


### PR DESCRIPTION
롯데 택배 배송완료 시간 파싱 에러 수정합니다.
|수정 전|수정 후|
|--|--|
|<img width="312" alt="image" src="https://github.com/shlee322/delivery-tracker/assets/55727443/74e0837d-0dd3-46aa-a86f-f4b58b7a0758">|<img width="293" alt="image" src="https://github.com/shlee322/delivery-tracker/assets/55727443/0c886b1d-0ef7-4514-8f86-32ae3c9c90b5">|