### PR TITLE
jp.yamato: Add TrackEventStatusCode case Delivered (in delivery box)

### DIFF
--- a/packages/core/src/carriers/jp.yamato/index.ts
+++ b/packages/core/src/carriers/jp.yamato/index.ts
@@ -137,6 +137,7 @@ class YamatoTrackScraper {
       case "輸送中": // In Transit
         return TrackEventStatusCode.InTransit;
       case "配達完了": // Delivered
+      case "配達完了（宅配ボックス）": // Delivered (in delivery box)
         return TrackEventStatusCode.Delivered;
     }
 


### PR DESCRIPTION
Yamato Transport's delivery status includes "Delivery Completed (Delivery Box)" when delivered to a delivery box. This patch can avoid non-existent statuses.